### PR TITLE
metiq: Support both upsample and downsample and needle length

### DIFF
--- a/src/audio_analyze.py
+++ b/src/audio_analyze.py
@@ -34,7 +34,7 @@ def get_correlation_indices(haystack, needle, **kwargs):
     min_separation = len(needle) // 2
     initial_index_list = np.flip(correlation.argsort()[-max_values:])
     index_list = []
-    CORRELATION_FACTOR = 10
+    CORRELATION_FACTOR = 2
     max_correlation = correlation[initial_index_list[0]]
     min_correlation = max_correlation / CORRELATION_FACTOR
     for index in initial_index_list:
@@ -96,13 +96,11 @@ def audio_analyze_wav(infile, **kwargs):
     haystack_samplerate, inaud = scipy.io.wavfile.read(infile)
     # force the input to the experiment samplerate
     if haystack_samplerate != samplerate:
-        if debug > 0:
-            print(
-                f"converting {infile} audio from {haystack_samplerate} to {samplerate}"
-            )
-        inaud = scipy.signal.decimate(inaud, int(haystack_samplerate / samplerate))
+        # There is a bug (https://github.com/scipy/scipy/issues/15620)
+        # resulting in all zeroes unless inout is cast to float
+        inaud = scipy.signal.resample_poly(inaud.astype(np.float32), int(samplerate/100) , int(haystack_samplerate/100),padtype='mean')
     # generate a 1-period needle
-    needle = audio_common.generate_beep(beep_period_sec, **kwargs)
+    needle = audio_common.generate_beep(beep_period_sec, **kwargs)[0:audio_common.DEFAULT_BEEP_DURATION_SAMPLES ]
     # calculate the correlation signal
     index_list, correlation = get_correlation_indices(inaud, needle)
     # add a samplerate-based timestamp
@@ -157,14 +155,14 @@ def get_options(argv):
         type=str,
         default=default_values["infile"],
         metavar="input-file",
-        help="input file",
+        help="input file [wav]",
     )
     parser.add_argument(
         "outfile",
         type=str,
         default=default_values["outfile"],
         metavar="output-file",
-        help="output file",
+        help="output file [csv]",
     )
     # do the parsing
     options = parser.parse_args(argv[1:])
@@ -198,7 +196,7 @@ def main(argv):
     # do something
     audio_results = audio_analyze(
         options.infile,
-        options.debug,
+        debug=options.debug,
     )
     dump_results(audio_results, options.outfile, options.debug)
 


### PR DESCRIPTION
* Non integer divisable samplerate combinations also needs to be supported
* The needle was too long signal, we only want to correlate the actual audio part of it.