### PR TITLE
metiq: add noise generator and coverage calculation

### DIFF
--- a/src/vft.py
+++ b/src/vft.py
@@ -92,6 +92,20 @@ def generate_graycode(width, height, vft_id, tag_border_size, value, debug):
     return generate(width, height, vft_id, tag_border_size, graycode_value, debug)
 
 
+def draw_tags(img, vft_id, tag_border_size, debug):
+    global vft_layout
+    width = img.shape[1]
+    height = img.shape[0]
+    if vft_layout is None:
+        vft_layout = VFTLayout(width, height, vft_id, tag_border_size)
+    # 2. add fiduciary markers (tags) in the top-left, top-right,
+    # and bottom-left corners
+    for tag_number in range(DEFAULT_TAG_NUMBER):
+        img = generate_add_tag(img, vft_layout, tag_number, debug)
+
+    return img
+
+
 def analyze_graycode(img, luma_threshold, lock_layout=False, debug=0):
     global vft_id
     bit_stream, vft_id = analyze(


### PR DESCRIPTION
* generate a noise video with only tags ex.: " metiq.py generate --noise --num-frames 10 -o out.mp4 Warning! mp4 should be y4m for an uncompressed original. Noise is hard to encode. "
* calulate tags on any video it will search until it finds tree or four tags and calculate the ratio from the original. Pass currently if more than 90% coverage. ex. " metiq.py analyze -i wn_comp.y4m --calc-coverage --- (1/1) -- wn_comp.y4m Pass: 100.0 % coverage "