### PR TITLE
metiq: accept three tags with lock_layout

### DIFF
--- a/src/video_analyze.py
+++ b/src/video_analyze.py
@@ -446,7 +446,7 @@ def find_first_valid_tag(infile, width, height, pixel_format, debug):
     tag_expected_center_locations = None
     ids = None
     vft_id = None
-    while tag_center_locations is None or len(tag_center_locations) < 4:
+    while tag_center_locations is None:
         status, img = video_capture.read()
 
         dim = (width, height)
@@ -475,6 +475,8 @@ def find_first_valid_tag(infile, width, height, pixel_format, debug):
     if tag_center_locations is None:
         raise vft.NoValidTagFoundError()
 
+    if debug > 0:
+        print(f"Found tags: {len(tag_center_locations) = }")
     return vft_id, tag_center_locations, tag_expected_center_locations
 
 


### PR DESCRIPTION
Less strict is better.

Maybe there is a better way to handle difficult identification situations?
However, in the limited samples I have checked it seems like if you find three tags that will be constant throughout and the fourth for some reason is not considered. 
With this fix at least we get those.
