### PR TITLE
metiq: Add coordinate freeze for manual tags

### DIFF
--- a/src/video_analyze.py
+++ b/src/video_analyze.py
@@ -406,7 +406,7 @@ def video_analyze(
                     vft_layout = vft.VFTLayout(width, height, _vft_id)
                     vft_id = _vft_id
                     tag_center_locations = _tag_center_locations
-                else:
+                elif not vtc.are_tags_frozen():
                     tag_center_locations = vtc.tag_frame(img)
                 status, value_read = parse_image(
                     img,

--- a/src/video_tag_coordinates.py
+++ b/src/video_tag_coordinates.py
@@ -7,49 +7,60 @@ import time
 
 
 coords = []
+clicked_coords = []
+freeze_tags = False
+
+
+def are_tags_frozen():
+    # no new tags will be looked at i.e. the setup is not moving
+    global freeze_tags
+    return freeze_tags
 
 
 def mouse_callback(event, x, y, flags, param):
-    global coords
+    global clicked_coords
     if event == cv2.EVENT_LBUTTONDOWN:
-        coords.append((x, y))
+        clicked_coords.append((x, y))
     elif event == cv2.EVENT_RBUTTONDOWN:
-        coords = []
+        clicked_coords = []
 
 
 def tag_frame(frame):
-    global coords
+    global coords, clicked_coords, freeze_tags
     name = "Tag coordinates"
-    old_coords = coords
 
-    coords = []
+    clicked_coords = []
     font = cv2.FONT_HERSHEY_SIMPLEX
     cv2.startWindowThread()
     cv2.namedWindow(name)
     cv2.imshow(name, frame)
     cv2.setMouseCallback(name, mouse_callback)
 
-    while len(coords) < 4:
+    while len(clicked_coords) < 4:
         key = cv2.waitKey(1)
 
         if key & 0xFF == ord("c"):
-            coords = old_coords
+            break
+
+        if key & 0xFF == ord("f"):
+            freeze_tags = True
             break
 
         framecopy = frame.copy()
-        for coord in old_coords:
-            cv2.circle(framecopy, coord, 5, (0, 0, 255), -1)
         for coord in coords:
+            cv2.circle(framecopy, coord, 5, (0, 0, 255), -1)
+        for coord in clicked_coords:
             cv2.circle(framecopy, coord, 5, (0, 255, 0), -1)
 
-        text = (
-            f"Click on tag centers, tags left: {4-len(coords)}, press 'c' to continue"
-        )
-        if len(old_coords) > 0:
-            text = f"Click on tag centers, tags left: {4-len(coords)}, press 'c' to use previous values"
+        text = f"Click on tag centers, tags left: {4-len(coords)}, press 'c' to continue, 'f' to freeze coordinates"
+        if len(coords) > 0:
+            text = f"Click on tag centers, tags left: {4-len(coords)}, press 'c' to use previous values, 'f' to freeze coordinates"
         cv2.putText(framecopy, text, (10, 30), font, 1, (255, 255, 255), 2, cv2.LINE_AA)
         cv2.putText(framecopy, text, (11, 31), font, 1, (0, 0, 0), 2, cv2.LINE_AA)
         cv2.imshow(name, framecopy)
+
+    if len(clicked_coords) == 4:
+        coords = clicked_coords
 
     cv2.destroyWindow(name)
 
@@ -62,7 +73,7 @@ def tag_frame(frame):
 
 
 def tag_video(video_path, width=-1, height=-1):
-    coords = None
+    global coords
     cap = cv2.VideoCapture(video_path)
 
     ret, frame = cap.read()
@@ -79,8 +90,8 @@ def tag_video(video_path, width=-1, height=-1):
         hratio = height / sheight
 
         coords = [(int(x * wratio), int(y * hratio)) for x, y in coords]
-
     cap.release()
+
     return coords
 
 


### PR DESCRIPTION
To simplify manual runs where the capture is stable, enable tags to be frozen, essentially just continue on parse error instead of asking for new coordinates.