### PR TITLE
Audio filter fix.

### DIFF
--- a/src/media_parse.py
+++ b/src/media_parse.py
@@ -32,9 +32,16 @@ def media_parse_audio(
     debug,
     **kwargs,
 ):
-    min_separation_msec = kwargs.get("min_separation_msec", audio_parse.DEFAULT_MIN_SEPARATION_MSEC)
-    min_match_threshold = kwargs.get("min_match_threshold", audio_parse.DEFAULT_MIN_MATCH_THRESHOLD)
+    min_separation_msec = kwargs.get(
+        "min_separation_msec", audio_parse.DEFAULT_MIN_SEPARATION_MSEC
+    )
+    min_match_threshold = kwargs.get(
+        "min_match_threshold", audio_parse.DEFAULT_MIN_MATCH_THRESHOLD
+    )
     audio_sample = kwargs.get("audio_sample", "")
+    bandpass_filter = kwargs.get(
+        "bandpass_filter", audio_parse.default_values["bandpass_filter"]
+    )
 
     audio_results = audio_parse.audio_parse(
         infile,
@@ -47,6 +54,7 @@ def media_parse_audio(
         min_separation_msec=min_separation_msec,
         min_match_threshold=min_match_threshold,
         audio_sample=audio_sample,
+        bandpass_filter=bandpass_filter,
         debug=debug,
     )
     if audio_results is None or len(audio_results) == 0:

--- a/src/metiq.py
+++ b/src/metiq.py
@@ -479,6 +479,15 @@ input_args = {
             "default": default_values["min_match_threshold"],
         },
     },
+    "bandpass_filter": {
+        "func": PARSE,
+        "short": "-bp",
+        "long": "--bandpass-filter",
+        "args": {
+            "action": "store_true",
+            "help": "Gentle butterworth bandpass filter. Sometimes low correlation hits can improve. Before lowering correlation threshold try filtering.",
+        },
+    },
 }
 
 
@@ -588,7 +597,6 @@ def main(argv):
             )
 
     elif options.func == PARSE:
-        print(f"parse: {options}")
         media_parse.media_parse(
             width=options.width,
             height=options.height,
@@ -608,6 +616,7 @@ def main(argv):
             threaded=options.threaded,
             tag_manual=options.tag_manual,
             min_match_threshold=options.min_match_threshold,
+            bandpass_filter=options.bandpass_filter,
             debug=options.debug,
         )
 

--- a/src/metiq_multi.py
+++ b/src/metiq_multi.py
@@ -406,9 +406,17 @@ def get_options(argv):
     parser.add_argument(
         "--min-match-threshold",
         type=float,
-        default= metiq.default_values["min_match_threshold"],
-        dest = "min_match_threshold",
+        default=metiq.default_values["min_match_threshold"],
+        dest="min_match_threshold",
         help="Minimum audio correlation threshold",
+    )
+    parser.add_argument(
+        "-bp",
+        "--bandpass-filter",
+        dest="bandpass_filter",
+        action="store_true",
+        default=metiq.default_values["bandpass_filter"],
+        help="Gentle butterworth bandpass filter. Sometimes low correlation hits can improve. Before lowering correlation threshold try filtering.",
     )
     options = parser.parse_args()
     return options
@@ -423,7 +431,9 @@ def run_file(kwargs):
     cleanup_video = kwargs.get("cleanup_video", False)
     z_filter = kwargs.get("z_filter", 3.0)
     debug = kwargs.get("debug", 0)
-    min_match_threshold = kwargs.get("min_match_threshold", metiq.default_values["min_match_threshold"])
+    min_match_threshold = kwargs.get(
+        "min_match_threshold", metiq.default_values["min_match_threshold"]
+    )
     print(f"{min_match_threshold=}")
     # We assume default settings on/ everything.
     # TODO(johan): expose more settings to the user
@@ -434,12 +444,14 @@ def run_file(kwargs):
     beep_freq = metiq.default_values["beep_freq"]
     beep_period_sec = metiq.default_values["beep_period_sec"]
     beep_duration_samples = metiq.default_values["beep_duration_samples"]
+    bandpass_filter = kwargs.get(
+        "bandpass_filter", metiq.default_values["bandpass_filter"]
+    )
     scale = metiq.default_values["scale"]
     pixel_format = metiq.default_values["pixel_format"]
     luma_threshold = metiq.default_values["luma_threshold"]
     num_frames = -1
     kwargs = {"lock_layout": True, "threaded": False}
-
 
     min_separation_msec = metiq.default_values["min_separation_msec"]
     audio_sample = metiq.default_values["audio_sample"]
@@ -466,8 +478,9 @@ def run_file(kwargs):
                 scale,
                 file,
                 audiocsv,
+                bandpass_filter=bandpass_filter,
                 min_match_threshold=min_match_threshold,
-                debug = debug,
+                debug=debug,
                 **kwargs,
             )
 
@@ -543,6 +556,7 @@ def main(argv):
                 "cleanup_video": not options.surpress_cleanup_video,
                 "z_filter": options.z_filter,
                 "min_match_threshold": options.min_match_threshold,
+                "bandpass_filter": options.bandpass_filter,
                 "debug": options.debug,
             }
         )


### PR DESCRIPTION
The filter order was too high and the low frequency threshold also too high. Adjusted these to be much more gentle values to not causing problems in good conditions.
Better to not filter unless needed.
There are a few ways to combat low audio correlation and few hits. 1) move the microphone and speakers so they are pointing towards eachother.
   Otherwise directivy can cause filtered capture.
2) Enable the bandpass filter for noiose captures. 3) Lower threshold for identified source. This can introduce false positives.