### PR TITLE
metiq: add missing python packages to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 numpy
 scipy
 graycode
-opencv-python==4.6.0.66
-opencv-contrib-python==4.6.0.66
+opencv-python
+opencv-contrib-python
+pandas
+Shapely
+matplotlib


### PR DESCRIPTION
Also, removed the versions on the packages.
Use latest unless problems arrise.

One working setup:
Name: numpy
    Version: 1.25.2
Name: scipy
    Version: 1.11.2
Name: graycode
    Version: 1.0.5
Name: opencv-python
    Version: 4.8.0.76
Name: opencv-contrib-python
    Version: 4.9.0.80
Name: pandas
    Version: 2.0.3
Name: shapely
    Version: 2.0.2
Name: matplotlib
    Version: 3.7.1